### PR TITLE
new: Add option to toggle fast random (#366)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -305,6 +305,16 @@ public class SodiumGameOptionPages {
                         .build()
                 )
                 .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName("Use Fast Random")
+                        .setTooltip("If enabled, a fast random function will be used for block rendering. This can affect the rotation of " +
+                                "randomly rotated textures when compared to vanilla.")
+                        .setControl(TickBoxControl::new)
+                        .setImpact(OptionImpact.LOW)
+                        .setBinding((opts, value) -> opts.advanced.useFastRandom = value, opts -> opts.advanced.useFastRandom)
+                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                        .build()
+                )
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
                         .setName("Animate Only Visible Textures")
                         .setTooltip("If enabled, only animated textures determined to be visible will be updated. This can provide a significant boost to frame " +
                                 "rates on some hardware. If you experience issues with some textures not being animated, disable this option.")

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -38,6 +38,7 @@ public class SodiumGameOptions {
         public boolean useChunkFaceCulling = true;
         public boolean useMemoryIntrinsics = true;
         public boolean disableDriverBlacklist = false;
+        public boolean useFastRandom = true;
     }
 
     public static class QualitySettings {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.pipeline;
 
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.model.light.LightMode;
 import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
 import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
@@ -31,7 +32,7 @@ import java.util.List;
 import java.util.Random;
 
 public class BlockRenderer {
-    private final Random random = new XoRoShiRoRandom();
+    private final Random random = SodiumClientMod.options().advanced.useFastRandom ? new XoRoShiRoRandom() : new Random();
 
     private final BlockColorsExtended blockColors;
     private final BlockOcclusionCache occlusionCache;


### PR DESCRIPTION
Sodium uses a different random source in its block renderer which is faster than vanilla. However, as a side effect, block rotations may be different when compared to vanilla, which can alter gameplay if players rely on the rotation of randomly rotated blocks. To solve this, an option to toggle the faster random function is added.